### PR TITLE
Fix README.md Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ spec:
 apiVersion: sql-server.dotkube.io/v1alpha1
 kind: Database
 metadata:
-  name: example-database
+  name: hello-world-database
   namespace: sqlserver-example
 spec:
   instanceName: sqlserver-instance
-  databaseName: HelloWorld
+  databaseName: hello-world
 
 ---
 apiVersion: sql-server.dotkube.io/v1alpha1
@@ -141,7 +141,7 @@ metadata:
   namespace: sqlserver-example
 spec:
   sqlServerName: sqlserver-instance
-  databaseName: HelloWorld
+  databaseName: hello-world
   loginName: adminuser
   roles:
     - db_owner
@@ -154,7 +154,7 @@ metadata:
   namespace: sqlserver-example
 spec:
   instanceName: sqlserver-instance
-  databaseName: HelloWorld
+  databaseName: hello-world
   schemaName: Reporting
   schemaOwner: adminuser
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ metadata:
   name: admin-login
   namespace: sqlserver-example
 spec:
-  databaseRef: example-database
+  sqlServerName: sqlserver-instance
   loginName: adminuser
   authenticationType: SQL
   secretName: sqlserver-secret
@@ -140,7 +140,8 @@ metadata:
   name: admin-user
   namespace: sqlserver-example
 spec:
-  databaseRef: example-database
+  sqlServerName: sqlserver-instance
+  databaseName: HelloWorld
   loginName: adminuser
   roles:
     - db_owner
@@ -152,7 +153,8 @@ metadata:
   name: reporting-schema
   namespace: sqlserver-example
 spec:
-  databaseRef: example-database
+  instanceName: sqlserver-instance
+  databaseName: HelloWorld
   schemaName: Reporting
   schemaOwner: adminuser
 ```
@@ -204,7 +206,7 @@ metadata:
   name: external-app-login
   namespace: external-sql-example
 spec:
-  databaseRef: external-app-database
+  sqlServerName: docker-sql-server
   loginName: externaluser
   authenticationType: SQL
   secretName: external-sql-secret
@@ -216,7 +218,8 @@ metadata:
   name: external-app-user
   namespace: external-sql-example
 spec:
-  databaseRef: external-app-database
+  sqlServerName: docker-sql-server
+  databaseName: ExternalAppDB
   loginName: externaluser
   roles:
     - db_datareader
@@ -229,7 +232,8 @@ metadata:
   name: external-app-schema
   namespace: external-sql-example
 spec:
-  databaseRef: external-app-database
+  instanceName: docker-sql-server
+  databaseName: ExternalAppDB
   schemaName: Application
   schemaOwner: externaluser
 ```


### PR DESCRIPTION
## Description
The examples in README.md were missing sqlServerName references in the login users. This PR fixes that so the Hello World actually works. 

Additionally, the database and kubernetes resource used inconsistent naming. I have made another commit addressing that. 

## Related Issue(s)
No related issue. 

## Checklist

PR is readme-only. 
- [ ] I have tested my changes locally.
- [ ] My code follows the project's coding guidelines.
- [ ] I have updated documentation, if needed.

